### PR TITLE
Removing Inventory command from definition file

### DIFF
--- a/port-monitor-definition.yml
+++ b/port-monitor-definition.yml
@@ -9,10 +9,3 @@ commands:
       - ./bin/port-monitor
       - --metrics
     interval: 30
-
-  inventory:
-    command:
-      - ./bin/port-monitor
-      - --inventory
-    prefix: config/port-monitor
-    interval: 30


### PR DESCRIPTION
Removing the inventory command from the definition file as this integration does not produce any inventory information.

No point in having the agent invoking the integrations at the defined interval to receive a blank payload. 